### PR TITLE
Start producing bundles targeting ES2015 and ES5

### DIFF
--- a/babel.config.es5.js
+++ b/babel.config.es5.js
@@ -1,0 +1,51 @@
+module.exports = (api) => {
+  const presets = [
+    ['@babel/preset-env', {
+      modules: false,
+      useBuiltIns: 'usage',
+      targets: {
+        esmodules: false,
+      },
+      exclude: ['transform-regenerator', 'transform-async-to-generator'],
+    }],
+    '@babel/preset-react',
+  ];
+
+  const plugins = [
+    '@babel/plugin-proposal-object-rest-spread',
+    '@babel/plugin-syntax-dynamic-import',
+    'lodash',
+    [
+      '@babel/plugin-proposal-class-properties',
+      {
+        spec: true,
+      },
+    ],
+    [
+      'module:fast-async',
+      {
+        spec: true,
+      },
+    ],
+  ];
+
+  if (api.env('test')) {
+    plugins.push(...[
+      '@babel/plugin-transform-modules-commonjs',
+      'dynamic-import-node',
+    ]);
+  }
+
+  if (api.env('production')) {
+    plugins.push(
+      ['transform-react-remove-prop-types', {
+        ignoreFilenames: ['node_modules'],
+      }],
+    );
+  }
+
+  return {
+    presets,
+    plugins,
+  };
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,25 +1,21 @@
 module.exports = (api) => {
   const presets = [
     ['@babel/preset-env', {
-      shippedProposals: true,
-      targets: '> 0.25% , not dead',
+      modules: false,
+      useBuiltIns: 'usage',
+      targets: {
+        esmodules: true,
+      },
       exclude: ['transform-regenerator', 'transform-async-to-generator'],
     }],
     '@babel/preset-react',
   ];
 
   const plugins = [
-    '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-syntax-dynamic-import',
     'lodash',
     [
       '@babel/plugin-proposal-class-properties',
-      {
-        spec: true,
-      },
-    ],
-    [
-      'module:fast-async',
       {
         spec: true,
       },

--- a/babel.config.node.js
+++ b/babel.config.node.js
@@ -1,0 +1,44 @@
+module.exports = (api) => {
+  const presets = [
+    ['@babel/preset-env', {
+      modules: false,
+      useBuiltIns: 'usage',
+      targets: {
+        node: 'current',
+      },
+      exclude: ['transform-regenerator', 'transform-async-to-generator'],
+    }],
+    '@babel/preset-react',
+  ];
+
+  const plugins = [
+    '@babel/plugin-syntax-dynamic-import',
+    'lodash',
+    [
+      '@babel/plugin-proposal-class-properties',
+      {
+        spec: true,
+      },
+    ],
+  ];
+
+  if (api.env('test')) {
+    plugins.push(...[
+      '@babel/plugin-transform-modules-commonjs',
+      'dynamic-import-node',
+    ]);
+  }
+
+  if (api.env('production')) {
+    plugins.push(
+      ['transform-react-remove-prop-types', {
+        ignoreFilenames: ['node_modules'],
+      }],
+    );
+  }
+
+  return {
+    presets,
+    plugins,
+  };
+};

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const production = require('./src/production');
 const test = require('./src/test');
 const hypernova = require('./src/hypernova');
 const developmentLegacy = require('./src/development_legacy');
+const productionLegacy = require('./src/production_legacy');
 
 module.exports = {
   development,
@@ -10,4 +11,5 @@ module.exports = {
   production,
   hypernova,
   developmentLegacy,
+  productionLegacy,
 };

--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ const development = require('./src/development');
 const production = require('./src/production');
 const test = require('./src/test');
 const hypernova = require('./src/hypernova');
+const developmentLegacy = require('./src/development_legacy');
 
 module.exports = {
   development,
   test,
   production,
   hypernova,
+  developmentLegacy,
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "css-loader": "^1.0.0",
     "fast-async": "7",
     "file-loader": "^2.0.0",
+    "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "hard-source-webpack-plugin": "^0.13.1",
     "js-yaml": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@futurelearn/webpack-config",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -3,39 +3,61 @@ const {
 } = require('path');
 const { safeLoad } = require('js-yaml');
 const { readFileSync } = require('fs');
+const { ensureSymlinkSync } = require('fs-extra');
 const { sync } = require('glob');
 
 const configPath = resolve('config', 'webpack.yml');
 const railsEnv = process.env.RAILS_ENV || 'production';
 const config = safeLoad(readFileSync(configPath), 'utf8')[railsEnv];
 
+ensureSymlinkSync(config.legacy_src_symlink, config.legacy_dest_symlink);
+
 const getEntries = (entryPaths) => {
-  const results = {};
+  const entries = {};
+  const legacyEntries = {};
+
   entryPaths.forEach(({
-    glob, use_dir_name: useDirName, root_path: rootPath, resolved_extensions: resolvedExtensions,
+    glob,
+    use_dir_name: useDirName,
+    root_path: rootPath,
+    resolved_extensions: resolvedExtensions,
+    legacy,
   }) => {
     const entryGlob = `${rootPath}${glob}{${resolvedExtensions.join(',')}}`;
     const paths = sync(entryGlob);
+
     paths.forEach((path) => {
       if (useDirName) {
         const entryDir = dirname(path);
         const entryDirWithoutRootPath = entryDir.replace(rootPath, '');
-        results[`${entryDirWithoutRootPath}`] = resolve(path);
+        if (legacy) {
+          legacyEntries[`${entryDirWithoutRootPath}`] = resolve(path);
+        } else {
+          entries[`${entryDirWithoutRootPath}`] = resolve(path);
+        }
       } else {
         const pathWithoutRootPath = path.replace(rootPath, '');
         const pathWithoutExtension = pathWithoutRootPath.replace(extname(path), '');
-        results[`${pathWithoutExtension}`] = resolve(path);
+        if (legacy) {
+          legacyEntries[`${pathWithoutExtension}`] = resolve(path);
+        } else {
+          entries[`${pathWithoutExtension}`] = resolve(path);
+        }
       }
     });
   });
 
-  return results;
+  return { entries, legacyEntries };
 };
 
+const { entries, legacyEntries } = getEntries(config.entry_paths);
+
 module.exports = {
-  entries: getEntries(config.entry_paths),
+  entries,
+  legacyEntries,
   extensions: config.extensions,
   resolvedPaths: config.resolved_paths,
+  legacyResolvedPaths: config.resolved_legacy_paths,
   cachePath: config.cache_path,
   output: {
     path: resolve(config.path),

--- a/src/development_legacy.js
+++ b/src/development_legacy.js
@@ -1,0 +1,17 @@
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+const shared = require('./shared_legacy');
+
+module.exports = {
+  ...shared,
+  mode: 'development',
+  name: 'development',
+  plugins: [
+    ...shared.plugins,
+    new WebpackAssetsManifest({
+      output: 'manifest-legacy.json',
+      entrypoints: true,
+      writeToDisk: true,
+      publicPath: shared.output.publicPath,
+    }),
+  ],
+};

--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -7,6 +7,7 @@ const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const shared = require('./shared');
 const config = require('./config');
 const serverSideLoaders = require('./server_side_loaders');
+const { hypernova } = require('./loaders');
 
 const hypernovaConfig = {
   ...shared,
@@ -18,7 +19,7 @@ const hypernovaConfig = {
     ...shared.module,
     rules: [
       ...Object.values(serverSideLoaders),
-      ...shared.module.rules,
+      ...Object.values(hypernova),
     ],
   },
   plugins: [

--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -47,17 +47,19 @@ const hypernovaConfig = {
 
 if (process.env.NODE_ENV === 'production') {
   hypernovaConfig.plugins.unshift(new HardSourceWebpackPlugin());
-  Object.assign(hypernovaConfig, { optimization: {
-    ...hypernovaConfig.optimization,
-    minimize: true,
-    minimizer: [new TerserPlugin({
-      parallel: true,
-      cache: true,
-      terserOptions: {
-        compress: false,
-      },
-    })],
-  }});
+  Object.assign(hypernovaConfig, {
+    optimization: {
+      ...hypernovaConfig.optimization,
+      minimize: true,
+      minimizer: [new TerserPlugin({
+        parallel: true,
+        cache: true,
+        terserOptions: {
+          compress: false,
+        },
+      })],
+    },
+  });
 }
 
 module.exports = hypernovaConfig;

--- a/src/loaders/babel.es5.js
+++ b/src/loaders/babel.es5.js
@@ -1,0 +1,17 @@
+const { join, resolve } = require('path');
+const { cachePath } = require('../config');
+
+module.exports = {
+  test: /\.(js|jsx)$/,
+  exclude: /node_modules/,
+  use: [
+    {
+      loader: 'babel-loader',
+      options: {
+        root: resolve(__dirname, '..', '..'),
+        configFile: resolve(__dirname, '..', '..', 'babel.config.es5.js'),
+        cacheDirectory: join(cachePath, 'babel-loader'),
+      },
+    },
+  ],
+};

--- a/src/loaders/babel.js
+++ b/src/loaders/babel.js
@@ -9,6 +9,7 @@ module.exports = {
       loader: 'babel-loader',
       options: {
         root: resolve(__dirname, '..', '..'),
+        configFile: resolve(__dirname, '..', '..', 'babel.config.js'),
         cacheDirectory: join(cachePath, 'babel-loader'),
       },
     },

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -2,10 +2,17 @@ const sass = require('./sass');
 const file = require('./file');
 const svg = require('./svg');
 const babel = require('./babel');
+const babelNode = require('../server_side_loaders/babel.node');
 
 module.exports.base = {
   sass,
   file,
   svg,
   babel,
+};
+
+module.exports.hypernova = {
+  file,
+  svg,
+  babelNode,
 };

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -3,7 +3,7 @@ const file = require('./file');
 const svg = require('./svg');
 const babel = require('./babel');
 
-module.exports = {
+module.exports.base = {
   sass,
   file,
   svg,

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -1,7 +1,9 @@
 const sass = require('./sass');
+const noSassLoader = require('../server_side_loaders/no_sass');
 const file = require('./file');
 const svg = require('./svg');
 const babel = require('./babel');
+const babelES5 = require('./babel.es5');
 const babelNode = require('../server_side_loaders/babel.node');
 
 module.exports.base = {
@@ -9,6 +11,13 @@ module.exports.base = {
   file,
   svg,
   babel,
+};
+
+module.exports.legacy = {
+  noSassLoader,
+  file,
+  svg,
+  babelES5,
 };
 
 module.exports.hypernova = {

--- a/src/production.js
+++ b/src/production.js
@@ -1,4 +1,3 @@
-const { relative } = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const TerserPlugin = require('terser-webpack-plugin');
@@ -20,7 +19,7 @@ module.exports = {
       sourceMap: false,
       terserOptions: {
         compress: false,
-        ecma: 5,
+        ecma: 8,
         warnings: false,
         safari10: true,
         ie8: false,

--- a/src/production_legacy.js
+++ b/src/production_legacy.js
@@ -1,0 +1,45 @@
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+const TerserPlugin = require('terser-webpack-plugin');
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+const { HashedModuleIdsPlugin, NamedChunksPlugin } = require('webpack');
+const shared = require('./shared_legacy');
+
+module.exports = {
+  ...shared,
+  name: 'production',
+  devtool: 'none',
+  optimization: {
+    ...shared.optimization,
+    minimize: true,
+    minimizer: [new TerserPlugin({
+      parallel: true,
+      cache: true,
+      sourceMap: false,
+      terserOptions: {
+        compress: false,
+        ecma: 5,
+        warnings: false,
+        safari10: true,
+        ie8: false,
+        output: {
+          ascii_only: true,
+        },
+      },
+    })],
+  },
+  plugins: [
+    ...shared.plugins,
+    new HardSourceWebpackPlugin(),
+    new HardSourceWebpackPlugin.ExcludeModulePlugin([{
+      test: /mini-css-extract-plugin[\\/]dist[\\/]loader/,
+    }]),
+    new HashedModuleIdsPlugin({}),
+    new NamedChunksPlugin(),
+    new WebpackAssetsManifest({
+      output: 'manifest-legacy.json',
+      entrypoints: true,
+      writeToDisk: true,
+      publicPath: shared.output.publicPath,
+    }),
+  ],
+};

--- a/src/server_side_loaders/babel.node.js
+++ b/src/server_side_loaders/babel.node.js
@@ -1,0 +1,17 @@
+const { join, resolve } = require('path');
+const { cachePath } = require('../config');
+
+module.exports = {
+  test: /\.(js|jsx)$/,
+  exclude: /node_modules/,
+  use: [
+    {
+      loader: 'babel-loader',
+      options: {
+        root: resolve(__dirname, '..', '..'),
+        configFile: resolve(__dirname, '..', '..', 'babel.config.node.js'),
+        cacheDirectory: join(cachePath, 'babel-loader'),
+      },
+    },
+  ],
+};

--- a/src/shared.js
+++ b/src/shared.js
@@ -13,7 +13,7 @@ module.exports = {
     },
   },
   module: {
-    rules: Object.values(loaders),
+    rules: Object.values(loaders.base),
   },
   mode: 'production',
   plugins: [

--- a/src/shared_legacy.js
+++ b/src/shared_legacy.js
@@ -1,0 +1,26 @@
+const config = require('./config');
+const loaders = require('./loaders');
+const { mode, plugins, optimization } = require('./shared');
+
+module.exports = {
+  entry: config.legacyEntries,
+  resolve: {
+    extensions: config.extensions,
+    modules: [...config.legacyResolvedPaths, 'node_modules'],
+    alias: {
+      tribute: 'tributejs/dist/tribute.min.js',
+    },
+  },
+  module: {
+    rules: Object.values(loaders.legacy),
+  },
+  mode,
+  plugins,
+  optimization,
+  output: {
+    path: config.output.path,
+    publicPath: config.output.publicPath,
+    filename: `[name]-[chunkhash]-${config.assetsVersion}.es5.js`,
+    chunkFilename: `[name]-[chunkhash]-${config.assetsVersion}.es5.js`,
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,15 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -2881,7 +2890,7 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -3582,6 +3591,13 @@ json5@^2.1.0:
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -6089,6 +6105,11 @@ unique-slug@^2.0.0:
   integrity sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==
   dependencies:
     imurmurhash "^0.1.4"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unquote@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
We want to remove our dependancy on polyfill.io for polyfilling our JavaScript. In order to accomplish this we want to once again start using `@babel/polyfills`. However we don't want to serve up more JavaScript than a browser needs (i.e. we don't need to polyfill `Promise` in latest Chrome)

In order to accomplish this, this PR makes it so that we are now producing a modern and legacy bundle. The modern bundle is targeting browsers that support `type="module"` and the legacy bundle browsers that don't.

We are taking advantage of `useBuiltIns: usage` so that we only include the polyfills that browsers need.

This PR is to support the main PR in the FL repo which will have the questions etc... This PR mainly gives us something to reference from it.