### PR TITLE
Fix null-loader excluding some React components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "@futurelearn/webpack-config",
+  "version": "3.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+    },
+    "inspect-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/inspect-loader/-/inspect-loader-1.0.0.tgz",
+      "integrity": "sha1-tbEVgjfgWVQPme2rhBlavUWHtEA=",
+      "requires": {
+        "loader-utils": "1.2.3"
+      }
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "1.2.0"
+      }
+    },
+    "loader-utils": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+      "requires": {
+        "big.js": "5.2.2",
+        "emojis-list": "2.1.0",
+        "json5": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@futurelearn/webpack-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/server_side_loaders/null_loader.js
+++ b/src/server_side_loaders/null_loader.js
@@ -1,4 +1,4 @@
 module.exports = {
-  test: /(c3|d3|react-select|velocity|tribute)/i,
+  test: /(c3|d3|react-select|tribute)/i,
   use: 'null-loader',
 };

--- a/src/server_side_loaders/null_loader.js
+++ b/src/server_side_loaders/null_loader.js
@@ -1,4 +1,5 @@
 module.exports = {
-  test: /(c3|d3|react-select|tribute)/i,
+  test: /node_modules.*\b(c3|d3|react-select|tribute)/i,
+  ],
   use: 'null-loader',
 };


### PR DESCRIPTION
This is less of a Pull Request, and more of a Request for Reckons from someone who doesn't know how webpack/hypernova works.

During firebreak I made a React component called `AWSAttributes.jsx`, which threw up weird hypernova errors from our server-side rendering.

Turns out our null-loader was matching the filename and excluding it.

As far as I can see (from adding an `inspect-loader`), these are the files the null-loader excludes:
```
/app/javascript/components/Shared/C3Chart/index.jsx
/app/javascript/components/Partials/CourseSchedule/D3HeatMap.js
/node_modules/tributejs/dist/tribute.min.js
```

So, I've tried to change the null-loader regex to:

1. Only exclude things in `node_modules`
2. Have an explicit list of our own Components we want to exclude.

As a result I have questions:

1. Are we excluding more files than the three above? I can't see any matches for `react-select`, `c3` or `d3` libraries when trying to see what webpack is doing.

2. Are we supposed to be excluding our own components `Shared/C3Chart/index.jsx` and `Partials/CourseSchedule/D3HeatMap.js`?


