### PR TITLE
Make null loader actually work with server side assets

### DIFF
--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -8,13 +8,16 @@ const shared = require('./shared');
 const config = require('./config');
 const serverSideLoaders = require('./server_side_loaders');
 const { hypernova } = require('./loaders');
+const CLIENT_SIDE_ONLY_PACKAGES = require('./server_side_loaders/client_side_only_packages');
 
 const hypernovaConfig = {
   ...shared,
   mode: process.env.NODE_ENV === 'development' ? 'development' : 'production',
   name: 'hypernova',
   target: 'node',
-  externals: [nodeExternals()],
+  externals: [nodeExternals({
+    whitelist: [CLIENT_SIDE_ONLY_PACKAGES],
+  })],
   devtool: 'none',
   module: {
     ...shared.module,

--- a/src/server_side_loaders/client_side_only_packages.js
+++ b/src/server_side_loaders/client_side_only_packages.js
@@ -1,0 +1,3 @@
+const CLIENT_SIDE_ONLY_PACKAGES = /\b(c3|d3|d3v4|react-select|tribute)\b/i;
+
+module.exports = CLIENT_SIDE_ONLY_PACKAGES;

--- a/src/server_side_loaders/null_loader.js
+++ b/src/server_side_loaders/null_loader.js
@@ -1,4 +1,6 @@
+const CLIENT_SIDE_ONLY_PACKAGES = require('./client_side_only_packages');
+
 module.exports = {
-  test: /node_modules.*\b(c3|d3|react-select|tribute)/i,
+  test: CLIENT_SIDE_ONLY_PACKAGES,
   use: 'null-loader',
 };


### PR DESCRIPTION
This has never actually work as we expected it to. Previously, we had a
regex that looked something like `/(c3|d3)/` which looking at you would
expect it to replace `import c3 from 'c3'` with the nulled version.

This never happened. Instead, it was just through pure luck that this
worked because the components that were using them happened to be
prefixed with `c3` or `d3`.

But why I hear you asking?

Well, for our hypernova assets we use something called `nodeExternals`
to tell Webpack that it doesn't need to bundle `node_modules`. This is
because node is capable of reading these off of the file system so
there's no need for us to include them as part of the bundle.

The issue this creates however, is that since these are no longer being
included in the bundle, we can no longer run any loaders against them,
hence why the `null-loader` was only ever running against our components
and not anything in `node_modules`.

To fix this, we are using the `whitelist` option for `nodeExternals` to
let through packages that we do want to be able to run the `null-loader`
over and then running the `null-loader` against these packages. Problem
solved :)

I'll bump the package version as part of merging this in.

# Questions?

* Is it worth defining the client side packages in our `webpack.yml` file on the Rails side?
* What am I doing with my life?
* Any other thoughts?