### PR TITLE
Allow webpack to generate hard-coded stylesheets in development

### DIFF
--- a/src/development.js
+++ b/src/development.js
@@ -2,7 +2,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const shared = require('./shared');
 
-module.exports = {
+const developmentConfig = {
   ...shared,
   mode: 'development',
   name: 'development',
@@ -40,3 +40,11 @@ module.exports = {
 
   },
 };
+
+if (process.env.USE_STYLESHEETS) {
+  developmentConfig.plugins.unshift(new MiniCssExtractPlugin({
+    filename: `[name].css`,
+  }));
+}
+
+module.exports = developmentConfig;

--- a/src/loaders/css_modules.js
+++ b/src/loaders/css_modules.js
@@ -10,11 +10,11 @@ const use = [
   ...DEFAULT_STYLE_LOADERS,
 ];
 
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' && !process.env.USE_STYLESHEETS) {
   use.unshift({ loader: 'style-loader' });
 }
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === 'production' || process.env.USE_STYLESHEETS) {
   use.unshift(MiniCssExtractPlugin.loader);
 }
 


### PR DESCRIPTION
This commit introduces a `USE_STYLESHEETS` environment variable that allows us to (optionally) generate hard-coded stylesheets in development.

We will separately update webpack's configuration in the main app to allow us to make use of this change.

The motivation here is that we currently have no easy way to test the styling of components that import their own styles when JavaScript is disabled. This will become more of a problem the more components become responsible for importing their own styles, and we will also need it in order to test the "old browser" (ie. largely no-JS) experience once we've started to [cut the mustard](https://github.com/Futurelearn/futurelearn/pull/2655).

We've tested this change in the main app on [a branch](https://github.com/Futurelearn/futurelearn/commits/nf-sm-import-styles) that points at this version of webpack-config, and it doesn't seem to break anything! Is there any reason not to go ahead and merge this?