### PR TITLE
Update null-loader regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@futurelearn/webpack-config",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -7,7 +7,7 @@ const shared = require('./shared');
 const config = require('./config');
 const serverSideLoaders = require('./server_side_loaders');
 const { hypernova } = require('./loaders');
-const CLIENT_SIDE_ONLY_PACKAGES = require('./server_side_loaders/client_side_only_packages');
+const { clientSideOnlyPackageNames } = require('./server_side_loaders/client_side_only_packages');
 
 const hypernovaConfig = {
   ...shared,
@@ -15,7 +15,7 @@ const hypernovaConfig = {
   name: 'hypernova',
   target: 'node',
   externals: [nodeExternals({
-    whitelist: [CLIENT_SIDE_ONLY_PACKAGES],
+    whitelist: clientSideOnlyPackageNames,
   })],
   devtool: 'none',
   module: {

--- a/src/server_side_loaders/client_side_only_packages.js
+++ b/src/server_side_loaders/client_side_only_packages.js
@@ -1,3 +1,14 @@
-const CLIENT_SIDE_ONLY_PACKAGES = /\b(c3|d3|d3v4|react-select|tribute)\b/i;
+const clientSideOnlyPackageNames = [
+  'c3',
+  'd3',
+  'd3v4',
+  'react-select',
+  'tribute',
+];
 
-module.exports = CLIENT_SIDE_ONLY_PACKAGES;
+const pathsRegex = new RegExp(`.*node_modules.*\\b(${clientSideOnlyPackageNames.join('|')})\\b`, 'i');
+
+module.exports = {
+  clientSideOnlyPackageNames,
+  clientSideOnlyPackagePaths: pathsRegex,
+};

--- a/src/server_side_loaders/null_loader.js
+++ b/src/server_side_loaders/null_loader.js
@@ -1,6 +1,6 @@
-const CLIENT_SIDE_ONLY_PACKAGES = require('./client_side_only_packages');
+const { clientSideOnlyPackagePaths } = require('./client_side_only_packages');
 
 module.exports = {
-  test: CLIENT_SIDE_ONLY_PACKAGES,
+  test: clientSideOnlyPackagePaths,
   use: 'null-loader',
 };


### PR DESCRIPTION
Sometimes, we do not want to load packages during server-side rendering.
For example, in cases where the JS expects the DOM to exist. We want
them to be used only the client-side.

To do this we use a combination of a null-loader (which rejects things
that match a pattern from a pack) and a nodeExternals whitelist (which
bundles certain packages instead of reading them from filesystem). See
01f2fc6 for an explanation of how this works.

We use one shared `CLIENT_SIDE_ONLY_PACKAGES` regex for both the
null-loader and the whitelist.

Recently we found some Jenkins CI builds failing if they included in
their branch name `c3`, `d3`, `react-select` etc. [2]

This happens because the nodeExternals whitelist is comparing the regex
to just the package name, but the null-loader is comparing the regex
against the full filepath, which includes the branch name.

Here we update `client_side_only_packages.js` to provide two different
loader tests, one for just names and another for full paths.

Here's an example of a passing jenkins build with `c3` in the branch name:

* https://jenkins.futurelearn.dev/blue/organizations/jenkins/CI%2Ffuturelearn/detail/dw-make-jenkins-webpack-fail-c3/9/pipeline

And here's it on playground, to verify eg facilitation dashboard still works:

* https://webpack.playground.futurelearn.com/

*Notes & Questions*

* Do the names make sense, and does the config seem sufficiently self-explanatory?
* I _think_ our null loader is not actually excluding  `tribute`, because the package is called `tributejs` but I'm not certain.

[1] 01f2fc6
[2] https://futurelearn.slack.com/archives/C025SEBUG/p1565108921303000