### PR TITLE
Don't use sass-resources-loader for CSS modules

### DIFF
--- a/src/loaders/default_style_loaders.js
+++ b/src/loaders/default_style_loaders.js
@@ -1,21 +1,9 @@
-const { resolve } = require('path');
-
 const DEFAULT_STYLE_LOADERS = [
   'resolve-url-loader',
   {
     loader: 'sass-loader',
     options: {
       sourceMap: true,
-    },
-  },
-  {
-    loader: 'sass-resources-loader',
-    options: {
-      resources: [
-        resolve('app', './assets/stylesheets/application/1-tools/_all.scss'),
-        resolve('app', './assets/stylesheets/application/2-brand/_all.scss'),
-        resolve('app', './assets/stylesheets/application/base/_all.scss'),
-      ],
     },
   },
 ];

--- a/src/loaders/sass.js
+++ b/src/loaders/sass.js
@@ -1,9 +1,20 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { resolve } = require('path');
 const DEFAULT_STYLE_LOADERS = require('./default_style_loaders');
 
 const use = [
   'css-loader',
   ...DEFAULT_STYLE_LOADERS,
+  {
+    loader: 'sass-resources-loader',
+    options: {
+      resources: [
+        resolve('app', './assets/stylesheets/application/1-tools/_all.scss'),
+        resolve('app', './assets/stylesheets/application/2-brand/_all.scss'),
+        resolve('app', './assets/stylesheets/application/base/_all.scss'),
+      ],
+    },
+  },
 ];
 
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
https://trello.com/c/KkoxiW3H

This loader made a bunch of SCSS mixins and variables available by default to any of our SCSS files or CSS modules.

We'd like to explicitly import dependencies rather than having them be available globally. As a first step, we are no longer making these global mixins and variables available to CSS modules by default.

To make sure our CSS modules continue to work after this commit is merged, we've updated our CSS modules to explicitly import their dependenies here: https://github.com/Futurelearn/futurelearn/pull/2756

We need to wait for that PR to be merged before this branch can be merged. I'm just putting this up to gain feedback so that I can make changes sooner rather than later if necessary.

## Questions

I'm not sure I totally understand how the semver should work for this. Is this a minor or major change?