### PR TITLE
Use ASSETS_HOST environment variable

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -61,8 +61,8 @@ module.exports = {
   cachePath: config.cache_path,
   output: {
     path: resolve(config.path),
-    publicPath: config.public_path,
-    hypernovaPublicPath: config.hypernova_public_path,
+    publicPath: process.env.ASSET_HOST ? `${process.env.ASSET_HOST}/packs/` : config.public_path,
+    hypernovaPublicPath: process.env.ASSET_HOST ? `${process.env.ASSET_HOST}/packs/server/` : config.hypernova_public_path,
   },
   assetsVersion: config.assets_version || '1.0',
 };


### PR DESCRIPTION
We want to be test compiling our webpack assets with an alternative hostname, without having to hard code it, and without it interfering with our exsitng `public_path` and `hypernova_public_path`.

This commit switches the `output.publicPath` and `output.hypernovaPublicPath` to use an `ASSETS_HOST` environment variable if it's present, otherwise it will fall back to the regular config.