### PR TITLE
Import vendor stylesheets without breaking SplitChunksPlugin

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -31,7 +31,11 @@ module.exports = {
         common: {
           test: /[\\/]node_modules[\\/]/,
           name(module) {
-            const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+            if (!module.nameForCondition) {
+              return true;
+            }
+
+            const packageName = module.nameForCondition().match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
             return `npm.${packageName.replace('@', '')}`;
           },
         },


### PR DESCRIPTION
https://trello.com/c/q5qmE4wg

We've customised SplitChunksPlugin to bundle modules by package. Because
we cannot directly access the package a module belongs to, we have to
infer the package name. Currently, we depend on `module.context` to do
this.

`module.context` appears to return the directory of the module's file.
So, if we have a module whose file lives at
node_modules/foo-package/src/foo.js, the module's context prop would
return node_modules/foo-package/src.

We can then use a regexp to pull out 'foo-package' as the package name.

Inferring the package name in this way worked fine until we started
trying to import vendor stylesheets into our application modules:

```
// app/javascript/bar/futurelearn-style-file.scss
@import 'node_modules/some-vendor/some-vendor.css';
```

sass-loader is responsible for converting some-vendor.css into a valid
module that webpack can understand; however, the resulting package's
context prop is not what we expected. Rather than
'node_modules/some-vendor/', it is 'app/javascript/bar/'. This caused
our config to error when importing vendor stylesheets into our
application modules.

This commit updates our configuration of SplitChunksPlugin to infer the
name of a package using `module.nameForCondition()` rather than
`module.context`.

The former appears to consistently return the path of the module's file
and is hopefully more reliable.

There are a few alternative solutions I considered, but ultimately
decided against:

* Exclude stylesheet modules from those processed by SplitChunksPlugin.
This is definitely a simple solution, but it feels a little arbitrary to
treat vendor JS differently to vendor CSS.

* Don't bundle based on package name. This changes how we bundle our
modules, which would require more time and effort to understand the
impact of. If we want to bundle our modules differently, I think we
should approach this separately.