### PR TITLE
Add jQuery as an external

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -49,4 +49,7 @@ module.exports = {
     filename: `[name]-[chunkhash]-${config.assetsVersion}.js`,
     chunkFilename: `[name]-[chunkhash]-${config.assetsVersion}.js`,
   },
+  externals: {
+    jquery: 'jQuery',
+  },
 };


### PR DESCRIPTION
We currently include jQuery in our app via Sprockets. However, some packages we bring in via Yarn and Webpack also depend on it. Currently, they load their own version of jQuery and don't use the global instance.

Adding jQuery as an "external" tells Webpack that whenever a file attempts to import the module named `jquery`, to not bother loading it, and use the existing `jQuery` global instead.

This _should_ only be temporary while we depend on jQuery from both our Sprockets and Webpack asset-pipelines. Once we've migrated everything (including jQuery) to our Webpack pipeline, we can figure out a better way – such as importing jQuery only into the files that still use it.

[1]: https://webpack.js.org/configuration/externals/#externals