### PR TITLE
Load safari-nomodule.js as a static file

### DIFF
--- a/src/loaders/file.js
+++ b/src/loaders/file.js
@@ -1,5 +1,8 @@
 module.exports = {
-  test: /\.(jpg|jpeg|png|gif|tiff|ico|svg|eot|otf|ttf|woff|woff2)$/i,
+  test: [
+    /\.(jpg|jpeg|png|gif|tiff|ico|svg|eot|otf|ttf|woff|woff2)$/i,
+    /app\/javascript\/vendor\/safari-nomodule.js/,
+  ],
   use: [
     {
       loader: 'file-loader',


### PR DESCRIPTION
The `safari-nomodule.js` polyfill needs to be inserted early on in the page before any other script tags with `type="module"` or `nomodule` attributes. As such, we don't really want to process it with Webpack, and we don't want to insert it in the page _after_ `runtime.js`.

Using `file-loader`, we'll get an entry in `manifest.json` named `app/javascript/vendor/safari-nomodule.js` that we can load with a regular `script` tag wherever/however we want.

@wannabefro do you have any thoughts on this, as you added `safari-nomodule.js` to the Sprockets asset-pipeline originally to get around this issue?