### PR TITLE
Use separate runtime for "init" scripts

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -41,7 +41,15 @@ module.exports = {
         },
       },
     },
-    runtimeChunk: 'single',
+    runtimeChunk: {
+      name(entrypoint) {
+        if (entrypoint.name === 'packs/applicationInit') {
+          return 'init';
+        }
+
+        return 'runtime';
+      },
+    },
   },
   output: {
     path: config.output.path,


### PR DESCRIPTION
We currently use a single runtime which is added to the page just before the first pack. Because we use the `type="module"` attribute on our script tags, the loading `runtime.js` (and any other chunks) is "deferred", meaning it is only executed once the document has been parsed (but before the `DOMContentLoaded` event) [1].

However, for some JavaScript, we want to load and execute it right away. In order to do this, we don't want to use `type="module"` on the script tag for that pack. That means we can't use a deferred runtime script either.

This commit changes the `runtimeChunk` setting to produce two runtime chunks: the existing `runtime.js` which we'll continue to use for deferred packs, and a separate `init.js` chunk that we can use for blocking packs (in this case there's only one `packs/applicationInit.js`).

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#Attributes

---

Questions:

1. Have I understood how the `runtimeChunk` option works? Will `runtime.js` continue to load all the packages it did previously?
2. Testing locally, my `init.js` chunk is much smaller than `runtime.js` (because I'm loading far fewer modules in `packs/applicationInit`) but it's still 7kb. And that 7kb will block the page rendering since it'll be loaded as a regular script instead of `type="module"` – is that acceptable?
3. We currently have "modern" and "legacy" bundles, and rely on browsers only loading one or the other by how they understand `type="module"` (loaded by modern browsers, not by legacy browser) and `nomodule` (loaded by legacy browsers, not by modern browsers). However, because this `init.js` runtime and `applicationInit.js` pack won't use `type="module"` or `nomodule` we'll have to choose _either_ the modern _or_ legacy version.