### PR TITLE
Remove jQuery external

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -49,7 +49,4 @@ module.exports = {
     filename: `[name]-[chunkhash]-${config.assetsVersion}.js`,
     chunkFilename: `[name]-[chunkhash]-${config.assetsVersion}.js`,
   },
-  externals: {
-    jquery: 'jQuery',
-  },
 };

--- a/src/shared_legacy.js
+++ b/src/shared_legacy.js
@@ -1,6 +1,6 @@
 const config = require('./config');
 const loaders = require('./loaders');
-const { mode, plugins, optimization, externals } = require('./shared');
+const { mode, plugins, optimization } = require('./shared');
 
 module.exports = {
   entry: config.legacyEntries,
@@ -23,5 +23,4 @@ module.exports = {
     filename: `[name]-[chunkhash]-${config.assetsVersion}.es5.js`,
     chunkFilename: `[name]-[chunkhash]-${config.assetsVersion}.es5.js`,
   },
-  externals,
 };


### PR DESCRIPTION
In 8a4f9a5 we added a `jquery` that told Webpack to use our global `jQuery` object instead of importing it from the `jquery` package. This was only intended to be a temporary measure, and we're now moving jQuery into our Webpack pipeline proper.