### PR TITLE
Do not change Hypernova config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -62,7 +62,7 @@ module.exports = {
   output: {
     path: resolve(config.path),
     publicPath: process.env.ASSET_HOST ? `${process.env.ASSET_HOST}/packs/` : config.public_path,
-    hypernovaPublicPath: process.env.ASSET_HOST ? `${process.env.ASSET_HOST}/packs/server/` : config.hypernova_public_path,
+    hypernovaPublicPath: config.hypernova_public_path,
   },
   assetsVersion: config.assets_version || '1.0',
 };


### PR DESCRIPTION
We do not want to serve webpack assets remotely, so when we compile Hypernova assets we want them in the same place they've always been.