### PR TITLE
Only use style-loader for CSS Modules

### DIFF
--- a/src/development.js
+++ b/src/development.js
@@ -1,3 +1,4 @@
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const shared = require('./shared');
 
@@ -7,6 +8,7 @@ module.exports = {
   name: 'development',
   plugins: [
     ...shared.plugins,
+    new MiniCssExtractPlugin(),
     new WebpackAssetsManifest({
       entrypoints: true,
       writeToDisk: true,

--- a/src/development.js
+++ b/src/development.js
@@ -20,7 +20,11 @@ module.exports = {
         common: {
           test: /[\\/]node_modules[\\/]/,
           name(module) {
-            const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+            if (!module.nameForCondition) {
+              return true;
+            }
+
+            const packageName = module.nameForCondition().match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
             return `npm.${packageName.replace('@', '')}`;
           },
         },

--- a/src/loaders/sass.js
+++ b/src/loaders/sass.js
@@ -3,6 +3,7 @@ const { resolve } = require('path');
 const DEFAULT_STYLE_LOADERS = require('./default_style_loaders');
 
 const use = [
+  MiniCssExtractPlugin.loader,
   'css-loader',
   ...DEFAULT_STYLE_LOADERS,
   {
@@ -16,14 +17,6 @@ const use = [
     },
   },
 ];
-
-if (process.env.NODE_ENV !== 'production') {
-  use.unshift({ loader: 'style-loader' });
-}
-
-if (process.env.NODE_ENV === 'production') {
-  use.unshift(MiniCssExtractPlugin.loader);
-}
 
 module.exports = {
   test: /\.(scss|sass|css)$/i,

--- a/src/test.js
+++ b/src/test.js
@@ -1,3 +1,4 @@
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const { DefinePlugin } = require('webpack');
 const shared = require('./shared');
@@ -7,6 +8,7 @@ module.exports = {
   name: 'test',
   plugins: [
     ...shared.plugins,
+    new MiniCssExtractPlugin(),
     new WebpackAssetsManifest({
       entrypoints: true,
       writeToDisk: true,


### PR DESCRIPTION
In order to move our stylesheets to webpack we want real CSS files for the main stylesheets in our app instead of using the style-loader.

This is also necessary as the Premailer gem requires an actual stylesheet to inline styles in emails.

This commit ensures we use `MiniCssExtractPlugin` for everything except CSS modules, which will still use the `style-loader`.