### PR TITLE
Use separate directory for server-side assets

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -62,6 +62,7 @@ module.exports = {
   output: {
     path: resolve(config.path),
     publicPath: process.env.ASSET_HOST ? `${process.env.ASSET_HOST}/packs/` : config.public_path,
+    hypernovaPath: resolve(config.hypernova_path),
     hypernovaPublicPath: config.hypernova_public_path,
   },
   assetsVersion: config.assets_version || '1.0',

--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -1,4 +1,3 @@
-const { resolve } = require('path');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const nodeExternals = require('webpack-node-externals');
 const { DefinePlugin } = require('webpack');

--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -44,7 +44,7 @@ const hypernovaConfig = {
   output: {
     ...shared.output,
     libraryTarget: 'commonjs',
-    path: resolve(shared.output.path, 'server'),
+    path: config.output.hypernovaPath,
   },
 };
 


### PR DESCRIPTION
We want to publish our server-side assets to a different directory than our client-side assets. This commit allows us to set a `hypernova_path` in our config, which can de different from the `path`.

This is so we can use our fonts for generating PDF's, without publicly exposing those files. There's no reason for us to publicly expose any of our server-assets because they're only used server-side.

---

Questions: 

- Is there anywhere we hardcode the server packs path?