### PR TITLE
Update config for print proof product PDF assets

### DIFF
--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -1,3 +1,4 @@
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 const nodeExternals = require('webpack-node-externals');
 const { DefinePlugin } = require('webpack');
@@ -26,6 +27,7 @@ const hypernovaConfig = {
   },
   plugins: [
     ...shared.plugins,
+    new MiniCssExtractPlugin(),
     new WebpackAssetsManifest({
       entrypoints: false,
       writeToDisk: true,

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -8,10 +8,17 @@ const babelNode = require('../server_side_loaders/babel.node');
 const serverCssModules = require('../server_side_loaders/css_modules');
 const cssModules = require('./css_modules');
 
+const fileWithoutPrintProductFonts = {
+  ...file,
+  exclude: [
+    /app\/assets\/fonts\/print_products/,
+  ],
+};
+
 module.exports.base = {
   sass,
   cssModules,
-  file,
+  file: fileWithoutPrintProductFonts,
   svg,
   babel,
 };
@@ -19,7 +26,7 @@ module.exports.base = {
 module.exports.legacy = {
   noSassLoader,
   serverCssModules,
-  file,
+  file: fileWithoutPrintProductFonts,
   svg,
   babelES5,
 };

--- a/src/server_side_loaders/index.js
+++ b/src/server_side_loaders/index.js
@@ -1,8 +1,10 @@
+const sass = require('../loaders/sass');
 const noSass = require('./no_sass');
 const nullLoader = require('./null_loader');
 const cssModules = require('./css_modules');
 
 module.exports = {
+  sass,
   noSass,
   nullLoader,
   cssModules,

--- a/src/server_side_loaders/no_sass.js
+++ b/src/server_side_loaders/no_sass.js
@@ -1,5 +1,9 @@
 module.exports = {
   test: /\.(scss|sass|css)$/i,
-  exclude: /\.module.(scss|sass|css)$/i,
+  exclude: [
+    /\.module.(scss|sass|css)$/i,
+    /print_products_download\.scss$/,
+    /print_products_printers\.scss$/,
+  ],
   use: 'null-loader',
 };


### PR DESCRIPTION
This branch does two things:

1. Prevents our server-side print proof product styles from being replaced with empty modules by `null-loader`.
2. Prevents our font files (which we need for server-side print proof product generation) from being exposed publicly, by telling the file loader to ignore them when generating client-side assets.

We'll do some follow up work to clean up the config so that we don't need to have all these inconsistencies between client-side and server-side assets, but for now this is the last thing preventing us from removing sprockets completely so we think it's OK.
