### PR TITLE
Use separate entrypoints for server/hypernova

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ ensureSymlinkSync(config.legacy_src_symlink, config.legacy_dest_symlink);
 const getEntries = (entryPaths) => {
   const entries = {};
   const legacyEntries = {};
+  const serverEntries = {};
 
   entryPaths.forEach(({
     glob,
@@ -22,6 +23,7 @@ const getEntries = (entryPaths) => {
     root_path: rootPath,
     resolved_extensions: resolvedExtensions,
     legacy,
+    server,
   }) => {
     const entryGlob = `${rootPath}${glob}{${resolvedExtensions.join(',')}}`;
     const paths = sync(entryGlob);
@@ -30,7 +32,9 @@ const getEntries = (entryPaths) => {
       if (useDirName) {
         const entryDir = dirname(path);
         const entryDirWithoutRootPath = entryDir.replace(rootPath, '');
-        if (legacy) {
+        if (server) {
+          serverEntries[`${entryDirWithoutRootPath}`] = resolve(path);
+        } else if (legacy) {
           legacyEntries[`${entryDirWithoutRootPath}`] = resolve(path);
         } else {
           entries[`${entryDirWithoutRootPath}`] = resolve(path);
@@ -38,7 +42,9 @@ const getEntries = (entryPaths) => {
       } else {
         const pathWithoutRootPath = path.replace(rootPath, '');
         const pathWithoutExtension = pathWithoutRootPath.replace(extname(path), '');
-        if (legacy) {
+        if (server) {
+          serverEntries[`${pathWithoutExtension}`] = resolve(path);
+        } else if (legacy) {
           legacyEntries[`${pathWithoutExtension}`] = resolve(path);
         } else {
           entries[`${pathWithoutExtension}`] = resolve(path);
@@ -47,14 +53,15 @@ const getEntries = (entryPaths) => {
     });
   });
 
-  return { entries, legacyEntries };
+  return { entries, legacyEntries, serverEntries };
 };
 
-const { entries, legacyEntries } = getEntries(config.entry_paths);
+const { entries, legacyEntries, serverEntries } = getEntries(config.entry_paths);
 
 module.exports = {
   entries,
   legacyEntries,
+  serverEntries,
   extensions: config.extensions,
   resolvedPaths: config.resolved_paths,
   legacyResolvedPaths: config.resolved_legacy_paths,

--- a/src/hypernova.js
+++ b/src/hypernova.js
@@ -11,6 +11,7 @@ const { clientSideOnlyPackageNames } = require('./server_side_loaders/client_sid
 
 const hypernovaConfig = {
   ...shared,
+  entry: config.serverEntries,
   mode: process.env.NODE_ENV === 'development' ? 'development' : 'production',
   name: 'hypernova',
   target: 'node',


### PR DESCRIPTION
This commit requires us to list separate entrypoints for server/hypernova assets by tagging them with a `server` flag.

This separation will allow us to be more selective about which files we actually need to compile for server/hypernova use, and likewise stop compiling some assets that _aren't_ used client-side.

I chose the to name the flag `server`, as it better describes that some of these assets are for use by hypernova, and others are used for server-side rendering of PDF certificates.