### PR TITLE
Use contenthash for file-loader names in production

### DIFF
--- a/src/loaders/file.js
+++ b/src/loaders/file.js
@@ -7,7 +7,7 @@ module.exports = {
     {
       loader: 'file-loader',
       options: {
-        name: '[path][name]-[hash].[ext]',
+        name: (process.env.NODE_ENV === 'production') ? '[path][name]-[contenthash].[ext]' : '[path][name].[ext]',
       },
     },
   ],


### PR DESCRIPTION
Previously `file-loader` was using `[hash]` in both production and development. In production this meant each time we rebuilt the assets images and fonts would have a different file name, even if the content hadn't changed, because `[hash]` is unique per file per build.

This commit changes the `name` option to use `[contenthash]` in production instead. This is a hash of the contents of the file, and so shouldn't change between deploys if the file is the same. It also changes development to not use a hash at all. I don't think `[hash]` is expensive, but not using it is consistent with our other files in development.