### PR TITLE
Stop creating symlink for legacy assets

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,14 +3,11 @@ const {
 } = require('path');
 const { safeLoad } = require('js-yaml');
 const { readFileSync } = require('fs');
-const { ensureSymlinkSync } = require('fs-extra');
 const { sync } = require('glob');
 
 const configPath = resolve('config', 'webpack.yml');
 const railsEnv = process.env.RAILS_ENV || 'production';
 const config = safeLoad(readFileSync(configPath), 'utf8')[railsEnv];
-
-ensureSymlinkSync(config.legacy_src_symlink, config.legacy_dest_symlink);
 
 const getEntries = (entryPaths) => {
   const entries = {};


### PR DESCRIPTION
We compile a set of "legacy" assets alongside our regular "modern"assets, to ensure we serve smaller bundles to newer browsers whilst also polyfilling behaviour for older browsers.

Previously, we created a symlink of our source files directory and used that with our legacy config. However, this was slower and more complicated than necessary, and have figured out an alternative approach. As such, we no longer need to create this symlink.