### PR TITLE
Simplify config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -60,7 +60,6 @@ module.exports = {
   serverEntries,
   extensions: config.extensions,
   resolvedPaths: config.resolved_paths,
-  legacyResolvedPaths: config.resolved_legacy_paths,
   cachePath: config.cache_path,
   output: {
     path: resolve(config.path),

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,14 @@ const configPath = resolve('config', 'webpack.yml');
 const railsEnv = process.env.RAILS_ENV || 'production';
 const config = safeLoad(readFileSync(configPath), 'utf8')[railsEnv];
 
+const entryName = ({ useDirName, rootPath, path }) => {
+  if (useDirName) {
+    return dirname(path).replace(rootPath, '');
+  } else {
+    return path.replace(rootPath, '').replace(extname(path), '');
+  }
+};
+
 const getEntries = (entryPaths) => {
   const entries = {};
   const legacyEntries = {};
@@ -25,26 +33,15 @@ const getEntries = (entryPaths) => {
     const paths = sync(entryGlob);
 
     paths.forEach((path) => {
-      if (useDirName) {
-        const entryDir = dirname(path);
-        const entryDirWithoutRootPath = entryDir.replace(rootPath, '');
-        if (server) {
-          serverEntries[`${entryDirWithoutRootPath}`] = resolve(path);
-        } else if (legacy) {
-          legacyEntries[`${entryDirWithoutRootPath}`] = resolve(path);
-        } else {
-          entries[`${entryDirWithoutRootPath}`] = resolve(path);
-        }
+      const key = entryName({ useDirName, rootPath, path });
+      const value = resolve(path);
+
+      if (server) {
+        serverEntries[key] = value;
+      } else if (legacy) {
+        legacyEntries[key] = value;
       } else {
-        const pathWithoutRootPath = path.replace(rootPath, '');
-        const pathWithoutExtension = pathWithoutRootPath.replace(extname(path), '');
-        if (server) {
-          serverEntries[`${pathWithoutExtension}`] = resolve(path);
-        } else if (legacy) {
-          legacyEntries[`${pathWithoutExtension}`] = resolve(path);
-        } else {
-          entries[`${pathWithoutExtension}`] = resolve(path);
-        }
+        entries[key] = value;
       }
     });
   });

--- a/src/config.js
+++ b/src/config.js
@@ -18,11 +18,10 @@ const getEntries = (entryPaths) => {
     glob,
     use_dir_name: useDirName,
     root_path: rootPath,
-    resolved_extensions: resolvedExtensions,
     legacy,
     server,
   }) => {
-    const entryGlob = `${rootPath}${glob}{${resolvedExtensions.join(',')}}`;
+    const entryGlob = `${rootPath}${glob}`;
     const paths = sync(entryGlob);
 
     paths.forEach((path) => {

--- a/src/config.js
+++ b/src/config.js
@@ -26,8 +26,7 @@ const getEntries = (entryPaths) => {
     glob,
     use_dir_name: useDirName,
     root_path: rootPath,
-    legacy,
-    server,
+    builds,
   }) => {
     const entryGlob = `${rootPath}${glob}`;
     const paths = sync(entryGlob);
@@ -36,11 +35,13 @@ const getEntries = (entryPaths) => {
       const key = entryName({ useDirName, rootPath, path });
       const value = resolve(path);
 
-      if (server) {
+      if (builds.includes('server')) {
         serverEntries[key] = value;
-      } else if (legacy) {
+      }
+      if (builds.includes('legacy')) {
         legacyEntries[key] = value;
-      } else {
+      }
+      if (builds.includes('main')) {
         entries[key] = value;
       }
     });

--- a/src/shared_legacy.js
+++ b/src/shared_legacy.js
@@ -6,7 +6,7 @@ module.exports = {
   entry: config.legacyEntries,
   resolve: {
     extensions: config.extensions,
-    modules: [...config.legacyResolvedPaths, 'node_modules'],
+    modules: [...config.resolvedPaths, 'node_modules'],
     alias: {
       tribute: 'tributejs/dist/tribute.min.js',
     },


### PR DESCRIPTION
This PR introduces a few changes to accommodate a simpler and more compact YAML config:

1. Remove `resolved_extensions` array and just add them directly to the `glob` instead
2. Remove `legacy_resolved_paths` as this is now identical to `resolved_paths`
3. Replace `server` and `legacy` booleans with `builds` array (e.g. `['main', 'legacy', 'server']`)

See the PR on the main repo for more details on these changes.